### PR TITLE
Energijos kaip žaidėjo statistikos pridėjimas

### DIFF
--- a/Escape From the Abyss/Assets/Scenes/SampleScene.unity
+++ b/Escape From the Abyss/Assets/Scenes/SampleScene.unity
@@ -2890,6 +2890,7 @@ RectTransform:
   - {fileID: 1375842290}
   - {fileID: 1967552718}
   - {fileID: 1949743746}
+  - {fileID: 1062297532}
   m_Father: {fileID: 963194228}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 30, y: 0, z: 0}
@@ -12759,6 +12760,109 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 9c9f65c1284b22247bafd1ebc8dbb632, type: 3}
+--- !u!1 &1062297531
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1062297532}
+  - component: {fileID: 1062297534}
+  - component: {fileID: 1062297535}
+  m_Layer: 0
+  m_Name: EnergyBar
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1062297532
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1062297531}
+  m_LocalRotation: {x: -0.000000029802315, y: -0.000000049860233, z: 0.000000044213646, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.550002}
+  m_LocalScale: {x: 0.029237445, y: 0.0172, z: 0.10000056}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1510763579}
+  m_Father: {fileID: 165192488}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -3.2799983, y: 2.7}
+  m_SizeDelta: {x: 100, y: 40}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1062297534
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1062297531}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 0
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 0
+  m_TargetGraphic: {fileID: 0}
+  m_FillRect: {fileID: 1510763579}
+  m_HandleRect: {fileID: 0}
+  m_Direction: 0
+  m_MinValue: 0
+  m_MaxValue: 50
+  m_WholeNumbers: 0
+  m_Value: 50
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &1062297535
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1062297531}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ae02d1fd6de48184d9759799f9d50ed2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  slider: {fileID: 1062297534}
 --- !u!1 &1067056985 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: -3542885339558904099, guid: 2f9e7d0bc5e07d64abdface1102df662, type: 3}
@@ -17118,6 +17222,82 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 1.0000026, y: 0.9352299, z: 1.910965}
   m_Center: {x: -0.000014230613, y: 0.46761298, z: 0.0133395195}
+--- !u!1 &1510763578
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1510763579}
+  - component: {fileID: 1510763581}
+  - component: {fileID: 1510763580}
+  m_Layer: 5
+  m_Name: EnergyFill
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1510763579
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1510763578}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 0}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1062297532}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1510763580
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1510763578}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.095674604, g: 0.6188645, b: 0.8113208, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1510763581
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1510763578}
+  m_CullTransparentMesh: 1
 --- !u!114 &1520401543 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 4999259395878273587, guid: 1a52aefe6d56c57459e9672aa03c769b, type: 3}
@@ -24726,7 +24906,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   maxHealth: 100
+  maxEnergy: 100
   healthBar: {fileID: 1949743749}
+  energyBar: {fileID: 1062297535}
   controller: {fileID: 1954952232}
 --- !u!114 &5866666020827666702
 MonoBehaviour:

--- a/Escape From the Abyss/Assets/Scripts/DataPersistence/Data/GameData.cs
+++ b/Escape From the Abyss/Assets/Scripts/DataPersistence/Data/GameData.cs
@@ -7,6 +7,7 @@ public class GameData
 {
     public int coinsCount;
     public int health;
+    public int energy;
     public Vector3 playerPosition;
 
     public GameData()
@@ -14,5 +15,6 @@ public class GameData
         this.coinsCount = 0;
         playerPosition = Vector3.zero;
         this.health = 0;
+        this.energy = 0;
     }
 }

--- a/Escape From the Abyss/Assets/Scripts/Energy.cs
+++ b/Escape From the Abyss/Assets/Scripts/Energy.cs
@@ -1,0 +1,22 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class Energy : MonoBehaviour
+{
+    
+    // Start is called before the first frame update
+    public int maxEnergy = 100;
+    public int currentEnergy;
+
+    public EnergyBar energyBar;
+
+
+    void Start()
+    {
+        currentEnergy = maxEnergy;
+        energyBar.SetMaxEnergy(maxEnergy);
+    }
+
+}

--- a/Escape From the Abyss/Assets/Scripts/Energy.cs.meta
+++ b/Escape From the Abyss/Assets/Scripts/Energy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 38e4cb36013cd58448f1225eb3866dff
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Escape From the Abyss/Assets/Scripts/EnergyBar.cs
+++ b/Escape From the Abyss/Assets/Scripts/EnergyBar.cs
@@ -1,0 +1,24 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class EnergyBar : MonoBehaviour
+{
+
+    public Slider slider;
+
+    // Start is called before the first frame update
+    public void SetMaxEnergy(int energy)
+    {
+        slider.maxValue = energy;
+        slider.value = energy;
+    }
+
+    // Update is called once per frame
+    public void SetEnergy(int energy)
+    {
+        slider.value = energy;
+    }
+  
+}

--- a/Escape From the Abyss/Assets/Scripts/EnergyBar.cs.meta
+++ b/Escape From the Abyss/Assets/Scripts/EnergyBar.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ae02d1fd6de48184d9759799f9d50ed2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Escape From the Abyss/Assets/Scripts/Health.cs
+++ b/Escape From the Abyss/Assets/Scripts/Health.cs
@@ -18,17 +18,5 @@ public class Health : MonoBehaviour
         healthBar.SetMaxHealth(maxHealth);
     }
 
-    void Update()
-    {
-        if (Input.GetKeyDown(KeyCode.Z))
-        {
-            TakeDamage(20);
-        }
-    }
 
-    void TakeDamage(int damage)
-    {
-        currentHealth -= damage;
-        healthBar.SetHealth(currentHealth);
-    }
 }

--- a/Escape From the Abyss/Assets/Scripts/PlayerScript.cs
+++ b/Escape From the Abyss/Assets/Scripts/PlayerScript.cs
@@ -6,25 +6,32 @@ using UnityEngine.UIElements;
 public class PlayerScript : MonoBehaviour, IDataPersistence
 {
     public int maxHealth;
+    public int maxEnergy;
     private int currentHealth;
+    private int currentEnergy;
 
     public HealthBar healthBar;
+    public EnergyBar energyBar;
     public GameController controller;
 
     public void LoadData(GameData data)
     {
         this.currentHealth = data.health;
+        this.currentEnergy = data.energy;
     }
 
     public void SaveData(ref GameData data)
     {
         data.health = this.currentHealth;
+        data.energy = this.currentEnergy;
     }
 
     private void Start()
     {
         currentHealth = maxHealth;
+        currentEnergy = maxEnergy;
         healthBar.SetMaxHealth(maxHealth);
+        energyBar.SetMaxEnergy(maxEnergy);
         setRigidbodyState(true);
         setColliderState(false);
         GetComponent<Animator>().enabled = true;
@@ -34,11 +41,17 @@ public class PlayerScript : MonoBehaviour, IDataPersistence
     {
         if (Input.GetKeyDown(KeyCode.Z))
         {
-            TakeDamage(20);
-            healthBar.SetHealth(currentHealth);
+            TakeEnergy(20);
+            energyBar.SetEnergy(currentEnergy);
         }
     }
-
+    void TakeEnergy(int damage)
+    {
+        currentEnergy -= damage;
+        energyBar.SetEnergy(currentEnergy);
+        //if (currentEber <= 0)
+           // die();
+    }
     void TakeDamage(int damage)
     {
         currentHealth -= damage;


### PR DESCRIPTION
Žaidėjo statistikos UI galima matyti mėlyną juostą, kuri atspindi žaidėjo turimą energijos kiekį, paspaudus Z/L raidę - energija nusiminusuoja siekiant ištestuoti/pademonstruoti, jog ir linija, atvaizduojanti energiją traukiasi.